### PR TITLE
Add sales and customer extractors

### DIFF
--- a/Api/GetCustomersInterface.php
+++ b/Api/GetCustomersInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (C) 2023 Searchspring <https://searchspring.com>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace SearchSpring\Feed\Api;
+
+use Magento\Framework\Exception\LocalizedException;
+
+interface GetCustomersInterface
+{
+    /**
+     * @param string $dateRange
+     * @param string $rowRange
+     *
+     * @return array
+     *
+     * @throws LocalizedException
+     */
+    public function getList(string $dateRange = "All", string $rowRange = "All");
+}

--- a/Api/GetSalesInterface.php
+++ b/Api/GetSalesInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright (C) 2023 Searchspring <https://searchspring.com>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace SearchSpring\Feed\Api;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use SearchSpring\Feed\Api\Data\CustomerResultsInterface;
+
+interface GetSalesInterface
+{
+    /**
+     * @param string $dateRange
+     * @param string $rowRange
+     *
+     * @return array
+     *
+     * @throws LocalizedException
+     */
+    public function getList(string $dateRange = "All", string $rowRange = "All");
+}

--- a/Api/GetVersionInterface.php
+++ b/Api/GetVersionInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright (C) 2023 Searchspring <https://searchspring.com>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace SearchSpring\Feed\Api;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use SearchSpring\Feed\Api\Data\CustomerResultsInterface;
+
+interface GetVersionInterface
+{
+    /**
+     * @return array
+     *
+     * @throws LocalizedException
+     */
+    public function get();
+}

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Helper to fetch customer data.
+ *
+ * This file is part of SearchSpring/Feed.
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace SearchSpring\Feed\Helper;
+
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory;
+use Magento\Framework\App\Helper\AbstractHelper;
+
+class Customer extends AbstractHelper
+{
+    protected $customerFactory;
+
+    public function __construct(CollectionFactory $customerFactory)
+    {
+        $this->customerFactory = $customerFactory;
+    }
+
+    public function getCustomers(string $dateRangeStr, string $rowRangeStr)
+    {
+        $result = [];
+        $customerCollection = $this->customerFactory->create();
+
+        $select = $customerCollection->getSelect();
+
+        // Build date range query.
+        $dateRange = Utils::getDateRange($dateRangeStr);
+        if ($dateRange) {
+            $customerCollection->addBindParam(':from', $dateRange[0]);
+            $condition = '(e.created_at >= :from OR e.updated_at >= :from)';
+
+            if (isset($dateRange[1])) {
+                $plusOneDay = Utils::plusOneDay($dateRange[1], 'Y-m-d');
+                $customerCollection->addBindParam(':to', $plusOneDay);
+                $condition = <<<SQL
+                    (
+                        (e.created_at >= :from AND e.created_at <= :to) 
+                        OR 
+                        (e.updated_at >= :from AND e.updated_at <= :to)
+                    )
+                SQL;
+            }
+
+            $select->where($condition);
+        }
+
+        // Chunk customers with row range.
+        $rowRange = Utils::getRowRange($rowRangeStr);
+        if (isset($rowRange[0]) && isset($rowRange[1])) {
+            $select->limit((int)$rowRange[1], (int)$rowRange[0]);
+        }
+
+        $items = $customerCollection->getItems(); // Make query
+        foreach ($items as $item) {
+            $result[] = [
+                'id' => $item->getId(),
+                'email' => $item->getEmail()
+            ];
+        }
+
+        return ['customers' => $result];
+    }
+}

--- a/Helper/Sale.php
+++ b/Helper/Sale.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Helper to fetch sale data.
+ *
+ * This file is part of SearchSpring/Feed.
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace SearchSpring\Feed\Helper;
+
+use DateTimeZone;
+use Magento\Config\Model\Config\Backend\Admin\Custom;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Store\Model\StoresConfig;
+use Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory;
+use DateTime;
+
+class Sale extends AbstractHelper
+{
+    protected $storesConfig;
+    protected $saleFactory;
+
+    public function __construct(StoresConfig $storesConfig, CollectionFactory $saleFactory)
+    {
+        $this->storesConfig = $storesConfig;
+        $this->saleFactory = $saleFactory;
+    }
+
+    function getSales(string $dateRangeStr, string $rowRangeStr)
+    {
+        $result = [];
+        $collection = $this->saleFactory->create();
+        $select = $collection->getSelect();
+
+        // Build date range query.
+        $dateRange = Utils::getDateRange($dateRangeStr);
+        if ($dateRange) {
+            $collection->addBindParam(':from', $dateRange[0]);
+
+            $condition = "(main_table.created_at >= :from OR main_table.updated_at >= :from)";
+            if (isset($dateRange[1])) {
+                $plusOneDay = Utils::plusOneDay($dateRange[1], $format = 'Y-m-d');
+                $collection->addBindParam(':to', $plusOneDay);
+                $condition = "(main_table.created_at >= :from AND main_table.created_at <= :to) OR (main_table.updated_at >= :from AND main_table.updated_at <= :to) ";
+            }
+            $select->where($condition);
+        }
+
+        // Chunk sales with row range.
+        $rowRange = Utils::getRowRange($rowRangeStr);
+        if (isset($rowRange[0]) && isset($rowRange[1])) {
+            $select->limit((int)$rowRange[1], (int)$rowRange[0]);
+        }
+
+        foreach($collection as $item){
+            $orderID = $item->getOrderID();
+
+            $order = $item->getOrder();
+            $customerID = $order->getData('customer_id');
+            if (empty($customerID)) {
+                $customerID = $order->getData('customer_email');
+            }
+
+            $productID = $item->getData('product_id');
+            $quantity = $item->getData('qty_ordered') - ($item->getData('qty_canceled') + $item->getData('qty_refunded'));
+            
+            // This has returned "" in the wild
+            $storeId = $item->getData('store_id');
+
+            // Normal storeIds start at "1", but the sneaky admin store is "0".
+            if($storeId == "0" || !empty($storeId)){
+                $zones = $this->getTimeZones();
+                $zone = $zones[$storeId];
+                $dt = new DateTime($item->getData('created_at'), new DateTimeZone($zone));
+            } else {
+                $dt = new DateTime($item->getData('created_at'));
+            }
+            $createdAt = $dt->format('Y-m-d H:i:sP');
+
+            $res = [
+                'order_id' => $orderID,
+                'customer_id' => $customerID,
+                'product_id' => $productID,
+                'quantity' => (string)$quantity,
+                'createdAt' => $createdAt,
+            ];
+            $result[] = $res;
+        }
+        return ['sales' => $result];
+    }
+
+    /**
+     * Get timezones used by the stores in this Magento setup.
+     *
+     * @return array
+     */
+    private function getTimeZones()
+    {
+        return $this->storesConfig->getStoresConfigByPath(Custom::XML_PATH_GENERAL_LOCALE_TIMEZONE);
+    }
+}

--- a/Helper/Utils.php
+++ b/Helper/Utils.php
@@ -1,0 +1,102 @@
+<?php
+namespace SearchSpring\Feed\Helper;
+
+use DateTime;
+
+// ##### DATE PARSE/VALIDATION STUFF #####
+// Note that the date input parameter is expected to be in the form of "YYYY-mm-dd,YYYY-mm-dd"
+// ValidateDateRange simply returns true if it's a valid range, false otherwise. It does not
+// compare values to see if they're in the proper order or anything like that. It only checks
+// to see if there are dates, and if they're in the proper format..
+
+class Utils
+{
+    // Tries to parse date to the format, returns true if it can be converted.
+    public static function validateDate($date, $format = 'Y-m-d')
+    {
+        $d = DateTime::createFromFormat($format, $date);
+        return $d && $d->format($format) == $date;
+    }
+
+    // Expands the input into an array. Or not.
+    public static function getDateRange($dateRange)
+    {
+        if ($dateRange != 'All') {
+            return explode(",", $dateRange);
+        }
+
+        return false;
+    }
+
+    // Checks to see if the input parameter provided in the get request contains two strings that
+    // can be parsed into valid dates. Returns true if they can be, false otherwise.
+    public static function validateDateRange($date_param)
+    {
+        $dateRange = Utils::getDateRange($date_param);
+        if ($dateRange) {
+            if (isset($dateRange[0])) {
+                if (!Utils::validateDate($dateRange[0])) {
+                    return false;
+                }
+            }
+            if (isset($dateRange[1])) {
+                if (!Utils::validateDate($dateRange[1])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    // ##### ROW RANGE/VALIDATION STUFF #####
+    // Row range enables chunking requests for getting sales on the Boost side.
+    // Row Range expects two comma seperated integers greater than 0.
+    // The first number minus one is the start index (zero-based) in the sale collection.
+    // The second number is the number of sales to chunk from the start index.
+    // For example, &dateRange=1,3 creates a chunk starting at sale element 0 and ending at
+    // sale element 2. And, &dateRange=10,3 creates a chunk starting at sale element 9
+    // and ending at sale element 11.
+    public static function getRowRange($row_param){
+        if ($row_param != 'All'){
+            $result = explode(",", $row_param);
+            $result[0] = (int)$result[0] - 1;
+            $result[1] = (int)$result[1];
+            return $result;
+        }
+
+        return false;
+    }
+
+    public static function validateRowRange($row_param) {
+        $isValidRowRange = true;
+        if ($row_param != 'All') {
+            $result = explode(",", $row_param);
+            if (count($result) != 2) {
+                $isValidRowRange = false;
+            }
+
+            if (isset($result[0])) {
+                $result[0] = (int) $result[0];
+                if ($result[0] <= 0) {
+                    $isValidRowRange = false;
+                }
+            }
+            if (isset($result[1])) {
+                $result[1] = (int) $result[1];
+                if ($result[1] <= 0) {
+                    $isValidRowRange = false;
+                }
+            }
+        }
+        return $isValidRowRange;
+    }
+
+    public static function plusOneDay($date, $format = 'Y-m-d')
+    {
+        $d = DateTime::createFromFormat($format, $date);
+        //PHP 5 >= 5.2.0
+        $d->modify('+1 day');
+        return $d->format($format);
+    }
+}

--- a/Helper/VersionInfo.php
+++ b/Helper/VersionInfo.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Helper to fetch version data.
+ *
+ * This file is part of SearchSpring/Feed.
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace SearchSpring\Feed\Helper;
+
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ProductMetadataInterface;
+
+class VersionInfo extends AbstractHelper
+{
+    const MODULE_NAME = 'SearchSpring_Feed';
+
+    /** @var ProductMetadataInterface */
+    private $productMetadata;
+
+    public function __construct(ProductMetadataInterface $productMetadata)
+    {
+        $this->productMetadata = $productMetadata;
+    }
+
+    public function getVersion()
+    {
+        $result = [];
+        $objectManager = ObjectManager::getInstance();
+
+        $version = null;
+        $module = $objectManager->get('\Magento\Framework\Module\ModuleListInterface')->getOne(self::MODULE_NAME);
+        if (!empty($module)) {
+            $version = $module['setup_version'];
+        }
+
+        $result[] = [
+            'extension' => $version,
+            'magento' => $this->productMetadata->getName() . '/' . $this->productMetadata->getVersion() . ' (' . $this->productMetadata->getEdition() . ')',
+            'memLimit' => $this->getMemoryLimit(),
+            'OSType' => php_uname($mode = "s"),
+            'OSVersion' => php_uname($mode = "v"),
+            'maxExecutionTime' => ini_get("max_execution_time")
+        ];
+
+        return $result;
+    }
+
+    public function getMemoryLimit()
+    {
+        $memoryLimit = trim(strtoupper(ini_get('memory_limit')));
+
+        if (!isSet($memoryLimit[0])) {
+            $memoryLimit = "128M";
+        }
+
+        if (substr($memoryLimit, -1) == 'K') {
+            return substr($memoryLimit, 0, -1) * 1024;
+        }
+        if (substr($memoryLimit, -1) == 'M') {
+            return substr($memoryLimit, 0, -1) * 1024 * 1024;
+        }
+        if (substr($memoryLimit, -1) == 'G') {
+            return substr($memoryLimit, 0, -1) * 1024 * 1024 * 1024;
+        }
+        return $memoryLimit;
+    }
+}

--- a/Model/GetCustomers.php
+++ b/Model/GetCustomers.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright (C) 2023 Searchspring <https://searchspring.com>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace SearchSpring\Feed\Model;
+
+use SearchSpring\Feed\Api\GetCustomersInterface;
+use SearchSpring\Feed\Exception\ValidationException;
+use SearchSpring\Feed\Helper\Customer;
+use SearchSpring\Feed\Helper\Utils;
+
+class GetCustomers implements GetCustomersInterface
+{
+    /** @var Customer */
+    private $helper;
+
+    /**
+     * @param Customer $helper
+     */
+    public function __construct(Customer $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @param string $dateRange
+     * @param string $rowRange
+     *
+     * @return array
+     *
+     * @throws ValidationException
+     */
+    public function getList(string $dateRange = "All", string $rowRange = "All")
+    {
+        $errors = [];
+        if (!Utils::validateDateRange($dateRange)){
+            $errors[] = "Invalid date range $dateRange";
+        }
+
+        if (!Utils::validateRowRange($rowRange)){
+            $errors[] = "Invalid row range $rowRange";
+        }
+
+        if (!empty($errors)){
+            throw new ValidationException($errors, 400);
+        }
+
+        return $this->helper->getCustomers($dateRange, $rowRange);
+    }
+}

--- a/Model/GetSales.php
+++ b/Model/GetSales.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright (C) 2023 Searchspring <https://searchspring.com>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace SearchSpring\Feed\Model;
+
+use SearchSpring\Feed\Api\GetSalesInterface;
+use SearchSpring\Feed\Exception\ValidationException;
+use SearchSpring\Feed\Helper\Sale;
+use SearchSpring\Feed\Helper\Utils;
+
+class GetSales implements GetSalesInterface
+{
+    /** @var Sale */
+    private $helper;
+
+    /**
+     * @param Sale $helper
+     */
+    public function __construct(Sale $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @param string $dateRange
+     * @param string $rowRange
+     *
+     * @return array
+     *
+     * @throws ValidationException
+     */
+    public function getList(string $dateRange = "All", string $rowRange = "All")
+    {
+        $errors = [];
+        if (!Utils::validateDateRange($dateRange)){
+            $errors[] = "Invalid date range $dateRange";
+        }
+
+        if (!Utils::validateRowRange($rowRange)){
+            $errors[] = "Invalid row range $rowRange";
+        }
+
+        if (!empty($errors)){
+            throw new ValidationException($errors, 400);
+        }
+
+        return $this->helper->getSales($dateRange, $rowRange);
+    }
+}

--- a/Model/GetVersion.php
+++ b/Model/GetVersion.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright (C) 2023 Searchspring <https://searchspring.com>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace SearchSpring\Feed\Model;
+
+use SearchSpring\Feed\Api\GetVersionInterface;
+use SearchSpring\Feed\Exception\ValidationException;
+use SearchSpring\Feed\Helper\VersionInfo;
+
+class GetVersion implements GetVersionInterface
+{
+    /** @var VersionInfo */
+    private $helper;
+
+    /**
+     * @param VersionInfo $helper
+     */
+    public function __construct(VersionInfo $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @return array
+     */
+    public function get()
+    {
+        return $this->helper->getVersion();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,9 @@
     "type": "magento2-module",
     "version": "1.0.0",
     "license": "GPL-3.0-only",
-    "require": {},
+    "require": {
+        "magento/module-customer": "*"
+    },
     "support": {
         "email": "support@searchspring.com"
     },

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -10,7 +10,9 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="SearchSpring_Feed::general" title="Searchspring" translate="title" sortOrder="900">
-                    <resource id="SearchSpring_Feed::task" title="Task" translate="title" sortOrder="10" />
+                    <resource id="SearchSpring_Feed::task" title="Products" translate="title" sortOrder="10" />
+                    <resource id="SearchSpring_Feed::customers" title="Customers" translate="title" sortOrder="20" />
+                    <resource id="SearchSpring_Feed::sales" title="Sales" translate="title" sortOrder="30" />
                 </resource>
             </resource>
         </resources>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,6 +21,12 @@
                 type="SearchSpring\Feed\Model\GenerateFeed"/>
     <preference for="SearchSpring\Feed\Api\ExecutePendingTasksInterface"
                 type="SearchSpring\Feed\Model\ExecutePendingTasks"/>
+    <preference for="SearchSpring\Feed\Api\GetVersionInterface"
+                type="SearchSpring\Feed\Model\GetVersion"/>
+    <preference for="SearchSpring\Feed\Api\GetCustomersInterface"
+                type="SearchSpring\Feed\Model\GetCustomers"/>
+    <preference for="SearchSpring\Feed\Api\GetSalesInterface"
+                type="SearchSpring\Feed\Model\GetSales"/>
     <preference for="SearchSpring\Feed\Api\ExecuteTaskInterface"
                 type="SearchSpring\Feed\Model\ExecuteTask"/>
     <preference for="SearchSpring\Feed\Api\GetStoresInfoInterface"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="SearchSpring_Feed">
+	<module name="SearchSpring_Feed" setup_version="1.1.0">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_Customer"/>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -2,6 +2,24 @@
 
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route url="/V1/searchspring/version" method="GET">
+        <service class="SearchSpring\Feed\Api\GetVersionInterface" method="get" />
+        <resources>
+            <resource ref="SearchSpring_Feed::general" />
+        </resources>
+    </route>
+    <route url="/V1/searchspring/customers" method="GET">
+        <service class="SearchSpring\Feed\Api\GetCustomersInterface" method="getList" />
+        <resources>
+            <resource ref="SearchSpring_Feed::customers" />
+        </resources>
+    </route>
+    <route url="/V1/searchspring/sales" method="GET">
+        <service class="SearchSpring\Feed\Api\GetSalesInterface" method="getList" />
+        <resources>
+            <resource ref="SearchSpring_Feed::sales" />
+        </resources>
+    </route>
     <route url="/V1/searchspring/info/html" method="GET">
         <service class="SearchSpring\Feed\Api\GetStoresInfoInterface" method="getAsHtml" />
         <resources>


### PR DESCRIPTION
Migrated code from old plugin to new plugin.
Most of the code is from original Boost Team code without changes.

Changed:
  - added authentication via oatuh
  - fixed possible sql injections

For future consideration:
  - use task scheduler to upload result files to our s3 instead of
    active polling paginated data

See: https://github.com/searchspring/magento2-searchspring-feed/

commit-id:aff1ff60

---

**Stack**:
- #6
- #5 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*