### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "searchspring/magento2-module",
     "type": "magento2-module",
-    "version": "1.0.0",
     "license": "GPL-3.0-only",
     "require": {
         "magento/module-customer": "*"


### PR DESCRIPTION
Php libraries should utilize git tags for library versioning and version
in composer.json should be ommited.

See: https://getcomposer.org/doc/04-schema.md#version

commit-id:044dc08b