### PR TITLE
Update magento/module-customer version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "version": "1.1.0",
     "license": "GPL-3.0-only",
     "require": {
-        "magento/module-customer": "*"
+        "magento/module-customer": "^103.0"
     },
     "support": {
         "email": "support@searchspring.com"


### PR DESCRIPTION
Magento review process requires specific module version and `*` used and
migrated from our old module was rejected during automated review.
Older version than currently required may be supported.
We decided that we will investigate and check documentation only in case client
with older version will request support.