### PR TITLE
fix-getMsiStatus-error

### DIFF
--- a/Model/Feed/Specification/Feed.php
+++ b/Model/Feed/Specification/Feed.php
@@ -335,7 +335,7 @@ class Feed extends AbstractExtensibleObject implements FeedSpecificationInterfac
      */
     public function getMsiStatus(): bool
     {
-        return $this->_get(self::MSI_STATUS);
+        return (bool)$this->_get(self::MSI_STATUS);
     }
 
     /**


### PR DESCRIPTION
This pull request makes a minor improvement to the `getMsiStatus` method in the `Feed.php` model. The change ensures that the returned value is always a boolean by explicitly casting the result.

* The `getMsiStatus` method now casts the returned value to boolean, guaranteeing type consistency.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213556053398819